### PR TITLE
Shell scripts for build rpm and deb binary package

### DIFF
--- a/dirty-debuild
+++ b/dirty-debuild
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+#
+# warn_if_bad		Put out warning message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#	Incoming $1 is returned unless it is 0
+#
+function warn_if_bad()
+{
+	local -i rc="$1"
+	local script="${0##*/}"
+
+	# Ignore if no problems
+	[ "${rc}" -eq "0" ] && return 0
+
+	# Broken
+	shift
+	echo "${script}: $@" >&2
+	return "${rc}"
+}
+
+#
+# exit_if_bad		Put out error message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#               Exits with 1 unless $1 is 0
+#
+function exit_if_bad()
+{
+	warn_if_bad "$@" || exit 1
+	return 0
+}
+
+TMP_DIR=""
+
+function internal_cleanup()
+{
+	[ -d "${TMP_DIR}" ] && rm -rf "${TMP_DIR}"
+}
+
+#trap internal_cleanup EXIT
+
+TMP_DIR="$(mktemp -d "/tmp/${0##*/}.XXXXXXXX" 2>/dev/null)"
+exit_if_bad "$?" "Above listed required command(s) not found."
+
+# Main
+if [ -z "$1" ]
+then
+	echo "Usage: ${0##*/} <goconserver binary tarball>"
+	echo
+	echo "Examples:"
+	echo "  ${0##*/} goconserver_linux_ppc64le.tar.gz"
+	echo "  ${0##*/} https://github.com/chenglch/goconserver/files/1505167/goconserver_linux_ppc64le.tar.gz"
+	exit 0
+fi
+
+BASE_DIR="${0%/*}"
+
+GOCONSERVER_BINARY_TARBALL="$1"
+"${BASE_DIR}/prep-tarball" "${GOCONSERVER_BINARY_TARBALL}"
+exit_if_bad "$?" "prep-tarball failed."
+
+tmp_b="${GOCONSERVER_BINARY_TARBALL##*/}"
+tmp_b="${tmp_b%%.*}"
+ARCH="${tmp_b##*_}"
+GOCONSERVER_REPACK_TARBALL="goconserver-repack-${ARCH}.tar.gz"
+
+case "${ARCH}" in
+"ppc64le")
+	ARCH="ppc64el"
+	;;
+esac
+
+cat <<-EOF >description-pak
+Independent tool to provide terminal session service.
+goconserver is written in golang and is a part of microservice of xcat3. It
+can work as a independent tool to provide the terminal session service.
+Terminal session could run in the background and help logging the terminal
+content.
+EOF
+
+# Make sure goconserver is not installed
+dpkg -P goconserver
+
+type checkinstall >/dev/null 2>&1
+exit_if_bad "$?" "Command not found - checkinstall"
+
+checkinstall --arch "${ARCH}" -D -y \
+	--pkgname goconserver \
+	--pkglicense EPL \
+	--pkgversion 0.1.0 \
+	--pkgrelease "snap$(date '+%Y%m%d%H%M')" \
+	--maintainer "gongjie@linux.vnet.ibm.com" \
+	--requires libc6 \
+	tar -x -C / -f "${GOCONSERVER_REPACK_TARBALL}"
+exit_if_bad "$?" "build package failed."
+
+rm -f description-pak
+dpkg -P goconserver

--- a/dirty-rpmbuild
+++ b/dirty-rpmbuild
@@ -1,0 +1,141 @@
+#!/bin/bash
+
+#
+# warn_if_bad		Put out warning message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#	Incoming $1 is returned unless it is 0
+#
+function warn_if_bad()
+{
+	local -i rc="$1"
+	local script="${0##*/}"
+
+	# Ignore if no problems
+	[ "${rc}" -eq "0" ] && return 0
+
+	# Broken
+	shift
+	echo "${script}: $@" >&2
+	return "${rc}"
+}
+
+#
+# exit_if_bad		Put out error message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#               Exits with 1 unless $1 is 0
+#
+function exit_if_bad()
+{
+	warn_if_bad "$@" || exit 1
+	return 0
+}
+
+TMP_DIR=""
+
+function internal_cleanup()
+{
+	[ -d "${TMP_DIR}" ] && rm -rf "${TMP_DIR}"
+}
+
+#trap internal_cleanup EXIT
+
+TMP_DIR="$(mktemp -d "/tmp/${0##*/}.XXXXXXXX" 2>/dev/null)"
+exit_if_bad "$?" "Above listed required command(s) not found."
+
+# Main
+if [ -z "$1" ]
+then
+	echo "Usage: ${0##*/} <goconserver binary tarball>"
+	echo
+	echo "Examples:"
+	echo "  ${0##*/} goconserver_linux_ppc64le.tar.gz"
+	echo "  ${0##*/} https://github.com/chenglch/goconserver/files/1505167/goconserver_linux_ppc64le.tar.gz"
+	exit 0
+fi
+
+BASE_DIR="${0%/*}"
+
+GOCONSERVER_BINARY_TARBALL="$1"
+"${BASE_DIR}/prep-tarball" "${GOCONSERVER_BINARY_TARBALL}"
+exit_if_bad "$?" "prep-tarball failed."
+
+tmp_b="${GOCONSERVER_BINARY_TARBALL##*/}"
+tmp_b="${tmp_b%%.*}"
+ARCH="${tmp_b##*_}"
+GOCONSERVER_REPACK_TARBALL="goconserver-repack-${ARCH}.tar.gz"
+
+GOCONSERVER_SPEC="${TMP_DIR}/goconserver.spec"
+
+
+case "${ARCH}" in
+"amd64")
+	ARCH="x86_64"
+	;;
+esac
+
+cat <<EOF >"${GOCONSERVER_SPEC}"
+Summary: Independent tool to provide terminal session service.
+Name: goconserver
+Version: 0.1.0
+Release: snap$(date '+%Y%m%d%H%M')
+License: EPL
+Group: Applications/System
+BuildArch: ${ARCH}
+URL: https://github.com/chenglch/goconserver/
+Vendor: IBM Corp.
+Packager: IBM Corp.
+Distribution: %{?_distribution:%{_distribution}}%{!?_distribution:%{_vendor}}
+Prefix: /
+BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+Source0: ${GOCONSERVER_REPACK_TARBALL}
+
+%description
+goconserver is written in golang and is a part of microservice of xcat3. It can work as a independent tool to provide the terminal session service. Terminal session could run in the background and help logging the terminal content.
+
+%prep
+
+%build
+
+%install
+mkdir -p \$RPM_BUILD_ROOT/%{prefix}
+( cd \$RPM_BUILD_ROOT/%{prefix} && tar xfz - ) <%{SOURCE0}
+
+%clean
+
+%files
+/etc/profile.d/congo.sh
+/etc/goconserver
+/etc/goconserver/server.conf
+/usr/lib/systemd/system/goconserver.service
+/usr/bin/goconserver
+/usr/bin/congo
+/var/lib/goconserver
+/var/log/goconserver
+/var/log/goconserver/nodes/
+
+EOF
+
+RPMROOT="$(rpmbuild --eval '%_topdir')"
+
+umask 0022
+mkdir -p "${RPMROOT}/SOURCES"
+cp "${GOCONSERVER_REPACK_TARBALL}" "${RPMROOT}/SOURCES"
+exit_if_bad "$?" "Copy ${GOCONSERVER_REPACK_TARBALL} failed."
+
+rpmbuild -bb "${GOCONSERVER_SPEC}" | tee "${TMP_DIR}/rpmbuild.log"
+exit_if_bad "$?" "rpmbuild failed."
+
+RPM_BIN="$(awk '/^Wrote: / { print $NF }' <"${TMP_DIR}/rpmbuild.log")"
+[ -n "${RPM_BIN}" ]
+exit_if_bad "$?" "Parse binary rpm package file name failed."
+[ -f "${RPM_BIN}" ]
+exit_if_bad "$?" "Binary rpm package not found."
+
+cp "${RPM_BIN}" .
+exit_if_bad "$?" "Copy ${RPM_BIN} failed."

--- a/prep-tarball
+++ b/prep-tarball
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+#
+# warn_if_bad		Put out warning message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#	Incoming $1 is returned unless it is 0
+#
+function warn_if_bad()
+{
+	local -i rc="$1"
+	local script="${0##*/}"
+
+	# Ignore if no problems
+	[ "${rc}" -eq "0" ] && return 0
+
+	# Broken
+	shift
+	echo "${script}: $@" >&2
+	return "${rc}"
+}
+
+#
+# exit_if_bad		Put out error message(s) if $1 has bad RC.
+#
+#	$1	0 (pass) or non-zero (fail).
+#	$2+	Remaining arguments printed only if the $1 is non-zero.
+#
+#               Exits with 1 unless $1 is 0
+#
+function exit_if_bad()
+{
+	warn_if_bad "$@" || exit 1
+	return 0
+}
+
+TMP_DIR=""
+
+function internal_cleanup()
+{
+	[ -d "${TMP_DIR}" ] && rm -rf "${TMP_DIR}"
+}
+
+trap internal_cleanup EXIT
+
+TMP_DIR="$(mktemp -d "/tmp/${0##*/}.XXXXXXXX" 2>/dev/null)"
+exit_if_bad "$?" "Above listed required command(s) not found."
+
+# Main
+if [ -z "$1" ]
+then
+	echo "Usage: ${0##*/} <goconserver binary tarball>"
+	exit 0
+fi
+
+GOCONSERVER_BINARY_TARBALL="$1"
+
+if [ "${GOCONSERVER_BINARY_TARBALL:0:7}" = "http://" -o \
+	"${GOCONSERVER_BINARY_TARBALL:0:8}" = "https://" ]
+then
+	wget -O "${GOCONSERVER_BINARY_TARBALL##*/}" "${GOCONSERVER_BINARY_TARBALL}" 
+	exit_if_bad "$?" "Downloading failed."
+
+	GOCONSERVER_BINARY_TARBALL="${GOCONSERVER_BINARY_TARBALL##*/}"
+fi
+
+[ -f "${GOCONSERVER_BINARY_TARBALL}" ]
+exit_if_bad "$?" "${GOCONSERVER_BINARY_TARBALL} - File not found."
+
+tmp_b="${GOCONSERVER_BINARY_TARBALL##*/}"
+tmp_b="${tmp_b%%.*}"
+ARCH="${tmp_b##*_}"
+GOCONSERVER_REPACK_TARBALL="goconserver-repack-${ARCH}.tar.gz"
+
+umask 0022
+
+mkdir -p "${TMP_DIR}/extract"
+( cd "${TMP_DIR}/extract" && tar xfz - ) <"${GOCONSERVER_BINARY_TARBALL}"
+
+mkdir -p "${TMP_DIR}/repack"
+mkdir -p "${TMP_DIR}/repack/etc/goconserver"
+mkdir -p "${TMP_DIR}/repack/etc/profile.d"
+mkdir -p "${TMP_DIR}/repack/usr/bin"
+mkdir -p "${TMP_DIR}/repack/usr/lib/systemd/system"
+mkdir -p "${TMP_DIR}/repack/var/log/goconserver/nodes"
+mkdir -p "${TMP_DIR}/repack/var/lib/goconserver"
+chmod 0700 "${TMP_DIR}/repack/etc/goconserver" \
+	"${TMP_DIR}/repack/var/log/goconserver" \
+	"${TMP_DIR}/repack/var/log/goconserver/nodes" \
+	"${TMP_DIR}/repack/var/lib/goconserver"
+install -o root -g root -m 0755 \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/goconserver" \
+	"${TMP_DIR}/repack/usr/bin"
+install -o root -g root -m 0755 \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/congo" \
+	"${TMP_DIR}/repack/usr/bin"
+install -o root -g root -m 0644 \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/etc/goconserver/server.conf" \
+	"${TMP_DIR}/repack/etc/goconserver"
+install -o root -g root -m 0644 \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/etc/goconserver/client.sh" \
+	"${TMP_DIR}/repack/etc/profile.d/congo.sh"
+install -o root -g root -m 0644 \
+	"${TMP_DIR}/extract/goconserver_linux_${ARCH}/etc/systemd/goconserver.service" \
+	"${TMP_DIR}/repack/usr/lib/systemd/system"
+
+( cd "${TMP_DIR}/repack" && tar cfz - *) >"${GOCONSERVER_REPACK_TARBALL}"
+
+# Verification
+
+ls -lad "${GOCONSERVER_REPACK_TARBALL}"
+tar tvfz "${GOCONSERVER_REPACK_TARBALL}"


### PR DESCRIPTION
```
# ./dirty-rpmbuild
Usage: dirty-rpmbuild <goconserver binary tarball>

Examples:
  dirty-rpmbuild goconserver_linux_ppc64le.tar.gz
  dirty-rpmbuild https://github.com/chenglch/goconserver/files/1505167/goconserver_linux_ppc64le.tar.gz
```