### PR TITLE
Use RFC3339 timestamps

### DIFF
--- a/common/conf.go
+++ b/common/conf.go
@@ -11,10 +11,10 @@ import (
 const (
 	PERIODIC_INTERVAL      = time.Minute
 	PIPELINE_SEND_INTERVAL = 300 * time.Millisecond
-	RFC8601_SECOND         = "2006-01-02T15:04:05Z0700"
-	RFC8601_MILLISECOND    = "2006-01-02T15:04:05Z0700.000"
-	RFC8601_MICROSECOND    = "2006-01-02T15:04:05Z0700.000000"
-	RFC8601_NANOSECOND     = "2006-01-02T15:04:05Z0700.000000000"
+	RFC3339_SECOND         = time.RFC3339
+	RFC3339_MILLISECOND    = "2006-01-02T15:04:05.000Z07:00"
+	RFC3339_MICROSECOND    = "2006-01-02T15:04:05.000000Z07:00"
+	RFC3339_NANOSECOND     = "2006-01-02T15:04:05.000000000Z07:00"
 	CLIENT_CONGO_TYPE      = iota
 	CLIENT_XCAT_TYPE
 )
@@ -49,10 +49,10 @@ var (
 		"y":    true,
 	}
 	PRECISION_FORMAT = map[string]string{
-		"second":      RFC8601_SECOND,
-		"millisecond": RFC8601_MILLISECOND,
-		"microsecond": RFC8601_MICROSECOND,
-		"nanosecond":  RFC8601_NANOSECOND}
+		"second":      RFC3339_SECOND,
+		"millisecond": RFC3339_MILLISECOND,
+		"microsecond": RFC3339_MICROSECOND,
+		"nanosecond":  RFC3339_NANOSECOND}
 )
 
 type FileCfg struct {
@@ -132,7 +132,7 @@ func InitServerConfig(confFile string) (*ServerConfig, error) {
 	serverConfig.Console.DataDir = "/var/lib/goconserver/"
 	serverConfig.Console.LogTimestamp = true
 	serverConfig.Console.TimePrecision = "microsecond"
-	serverConfig.Console.TimeFormat = RFC8601_MICROSECOND
+	serverConfig.Console.TimeFormat = RFC3339_MICROSECOND
 	serverConfig.Console.ReplayLines = 30
 	serverConfig.Console.ClientTimeout = 30
 	serverConfig.Console.TargetTimeout = 30

--- a/console/console.go
+++ b/console/console.go
@@ -125,7 +125,7 @@ func (self *Console) writeClient(conn net.Conn) {
 	var ok bool
 	clientTimeout := time.Duration(serverConfig.Console.ClientTimeout)
 	welcome := fmt.Sprintf("goconserver(%s): Hello %s, welcome to the session of %s",
-		time.Now().Format(common.RFC8601_SECOND), conn.RemoteAddr().String(), self.node.StorageNode.Name)
+		time.Now().Format(common.RFC3339_SECOND), conn.RemoteAddr().String(), self.node.StorageNode.Name)
 	err := common.Network.SendByteWithLengthTimeout(conn, []byte(welcome+"\r\n"), clientTimeout)
 	if err != nil {
 		plog.InfoNode(self.node.StorageNode.Name, fmt.Sprintf("Failed to send message to client. Error:%s", err.Error()))

--- a/console/pipeline/logger.go
+++ b/console/pipeline/logger.go
@@ -206,7 +206,7 @@ func (self *ByteLogger) insertStamp(b []byte, newLine *bool) ([]byte, error) {
 	}()
 	for i := 0; i < len(b); i++ {
 		if *newLine {
-			buf.WriteString("\n[" + time.Now().Format(common.RFC8601_SECOND) + "] ")
+			buf.WriteString("\n[" + time.Now().Format(common.RFC3339_SECOND) + "] ")
 			*newLine = false
 		}
 		if b[i] == '\n' {
@@ -265,7 +265,7 @@ func (self *ByteLogger) Prompt(node string, message string) error {
 		message = message + "\r\n"
 	}
 	if serverConfig.Console.LogTimestamp {
-		message = "\r\n[" + time.Now().Format(common.RFC8601_SECOND) + "] " + message
+		message = "\r\n[" + time.Now().Format(common.RFC3339_SECOND) + "] " + message
 	}
 	for _, publisher := range self.publishers {
 		err = publisher.Publish(node, []byte(message))


### PR DESCRIPTION
RFC3339 implements ISO8601. "It is a conformant subset of the ISO 8601 extended format. Simplicity is achieved by making most fields and punctuation mandatory."
partial-issue: #19