### PR TITLE
Update Makefile to build rpm or deb package directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+GOPATH?=$(shell pwd)
+export GOPATH
+PATH+=:$(shell pwd)/bin
+export PATH
 GITHUB_DIR=${GOPATH}/src/github.com/chenglch/
 REPO_DIR=${GOPATH}/src/github.com/chenglch/goconserver
 CURRENT_DIR=$(shell pwd)
@@ -70,9 +74,16 @@ tar: build
 	cd - ;\
 	tar cvfz build/goconserver_${PLATFORM}_${ARCH}.tar.gz -C build goconserver_${PLATFORM}_${ARCH}
 
+deb: tar
+	cd build && VERSION=${VERSION} ../dirty-debuild goconserver_${PLATFORM}_${ARCH}.tar.gz
+
+rpm: tar
+	cd build && VERSION=${VERSION} ../dirty-rpmbuild goconserver_${PLATFORM}_${ARCH}.tar.gz
+
 clean:
 	rm -f ${SERVER_BINARY}
 	rm -f ${CLIENT_BINARY}
 	rm -rf build
+	rm -rf bin pkg
 
-.PHONY: binary deps fmt build clean link tar
+.PHONY: binary deps fmt build clean link tar deb rpm

--- a/dirty-debuild
+++ b/dirty-debuild
@@ -93,7 +93,7 @@ exit_if_bad "$?" "Command not found - checkinstall"
 checkinstall --arch "${ARCH}" -D -y \
 	--pkgname goconserver \
 	--pkglicense EPL \
-	--pkgversion 0.2.1 \
+	--pkgversion ${VERSION:-0.0.1} \
 	--pkgrelease "snap$(date '+%Y%m%d%H%M')" \
 	--maintainer "gongjie@linux.vnet.ibm.com" \
 	--requires libc6 \

--- a/dirty-rpmbuild
+++ b/dirty-rpmbuild
@@ -82,7 +82,7 @@ esac
 cat <<EOF >"${GOCONSERVER_SPEC}"
 Summary: Independent tool to provide terminal session service.
 Name: goconserver
-Version: 0.2.1
+Version: ${VERSION:-0.0.1}
 Release: snap$(date '+%Y%m%d%H%M')
 License: EPL
 Group: Applications/System


### PR DESCRIPTION
In this way, run `make rpm` or `make deb` to create rpm or deb binary package.